### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install react-native-flatlist-alphabet
 or with yarn:
 
 ```bash
-yard add react-native-flatlist-alphabet
+yarn add react-native-flatlist-alphabet
 ```
 
 ## Usage


### PR DESCRIPTION
# Description

in the install with yarn example is a small typo. `yard` instead of `yarn`